### PR TITLE
Update date format in-line with designs

### DIFF
--- a/src/components/CommentApp/components/CommentFooter/index.tsx
+++ b/src/components/CommentApp/components/CommentFooter/index.tsx
@@ -25,7 +25,7 @@ export const CommentFooter: FunctionComponent<CommentFooterProps> = ({
     <div className="comment-footer">
       <span id={descriptionId}>
         <p className="comment-footer__author comment-footer__date">
-          {author ? author.firstname : ''} {author ? author.lastname : ''} | {dateFormat(date, 'HH:MM mmmm d')}
+          {author ? author.firstname : ''} {author ? author.lastname : ''} | {dateFormat(date, 'd mmmm yyyy, HH:MM')}
         </p>
       </span>
     </div>


### PR DESCRIPTION
Update date format to match up with most recent design changes.
Date should now be formatted as "28 May 2021, 09:30".