### PR TITLE
Remove-focused-comment-animation

### DIFF
--- a/src/components/CommentApp/components/Comment/style.scss
+++ b/src/components/CommentApp/components/Comment/style.scss
@@ -8,8 +8,6 @@
     pointer-events: auto;
     box-sizing: border-box;
     right: -2000px;
-    margin-left: 20px;
-    margin-right: 20px;
 
 
     &:hover {
@@ -27,10 +25,7 @@
 
 
     &--focused {
-        right: 35px;
         border: 3px solid #005eb8;
-        margin-left: 0;
-        margin-right: 40px;
 
         .comment-reply {
             border-bottom: 1px solid #005eb8;

--- a/src/components/CommentApp/components/CommentsTabs/style.scss
+++ b/src/components/CommentApp/components/CommentsTabs/style.scss
@@ -1,7 +1,6 @@
 .comments-tabs {
     margin-bottom: 20px;
     max-width: 470px;
-    padding: 0 20px;
     border-bottom: 0;
 
     .nav-link {


### PR DESCRIPTION
Remove left animation for focussed comments.
Remove 20px horizontal padding for entire commenting component.