### PR TITLE
Fix/ghost html

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-react-commenting-component",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/src/components/CommentApp/components/Comment/index.tsx
+++ b/src/components/CommentApp/components/Comment/index.tsx
@@ -256,7 +256,10 @@ function removeHighlightContent(comment: Comment) {
   }
   if (highlightElements) {
     for (let elem = 0; elem < highlightElements.length; elem++) {
-      highlightElements[elem].replaceWith(highlightElements[elem].innerHTML);
+      const innerText = highlightElements[elem].textContent;
+      if (innerText) {
+        highlightElements[elem].replaceWith(highlightElements[elem].textContent!);
+      }
     }
   }
 }


### PR DESCRIPTION
Use innerText instead of innerHTML to ensure rogue HTML characters don't appear.