### PR TITLE
Fix reply menu appearing when thread is resolved

### DIFF
--- a/src/components/CommentApp/components/CommentReply/index.tsx
+++ b/src/components/CommentApp/components/CommentReply/index.tsx
@@ -137,9 +137,9 @@ export default class CommentReplyComponent extends React.Component<CommentReplyP
   renderReplyMenu(): React.ReactFragment {
     const { comment, reply, store, strings, isFocused } = this.props;
 
-    // If comment is resolved, don't show menu
+    // If comment is resolved or page status is approved, don't show menu
     const status = getStatus();
-    if (status === 'Approved') {
+    if (status === 'Approved' || comment.resolved) {
       return <></>;
     }
     // Show edit/delete buttons if this reply was authored by the current user


### PR DESCRIPTION
Ensure the reply menu doesn't appear when the thread containing the reply is resolved.